### PR TITLE
(ios) Fixed JSON serialization for streams with infinite stream duration

### DIFF
--- a/src/ios/MLPCastUtilities.m
+++ b/src/ios/MLPCastUtilities.m
@@ -588,7 +588,7 @@ NSDictionary* queueOrderIDsByItemId = nil;
     returnDict[@"contentId"] = mediaInfo.contentID? mediaInfo.contentID : mediaInfo.contentURL.absoluteString;
     returnDict[@"contentType"] = mediaInfo.contentType;
     returnDict[@"customData"] = mediaInfo.customData == nil ? @{} : mediaInfo.customData;
-    returnDict[@"duration"] = @(mediaInfo.streamDuration);
+    returnDict[@"duration"] = mediaInfo.streamDuration == INFINITY ? nil : @(mediaInfo.streamDuration);
     returnDict[@"metadata" ] = [MLPCastUtilities createMetadataObject:mediaInfo.metadata];
     returnDict[@"streamType"] = [MLPCastUtilities getStreamType:mediaInfo.streamType];
     returnDict[@"tracks"] = [MLPCastUtilities getMediaTracks:mediaInfo.mediaTracks];


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation and Context

This fixes #11 


### Testing

I've used the [example](https://github.com/miloproductionsinc/cordova-plugin-chromecast/blob/master/doc/example.js) and replaced the mp4-URL with a live-audio-stream (eg. mp3).


### Checklist

- [ ] I've updated the documentation as necessary
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've run `npm test` and no errors were found (run `npm style` to auto-fix errors it can)
- [ ] I've run the tests (See Readme)
- [ ] I added automated test coverage as appropriate for this change (See Readme Contributing section)