### PR TITLE
Fixed issue when using the sendMessage method on iOS implementation

### DIFF
--- a/src/ios/MLPChromecastSession.m
+++ b/src/ios/MLPChromecastSession.m
@@ -214,21 +214,24 @@ NSMutableArray<MLPCastRequestDelegate*>* requestDelegates;
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
-- (void)sendMessageWithCommand:(CDVInvokedUrlCommand*)command namespace:(NSString*)namespace message:(NSString*)message {
-    GCKGenericChannel* channel = self.genericChannels[namespace];
-    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[NSString stringWithFormat:@"Namespace %@ not founded",namespace]];
+- (void)sendMessageWithCommand:(CDVInvokedUrlCommand*)command namespace:(NSString*)namespace message:(NSString*)message{
+
+    GCKGenericChannel* newChannel = [[GCKGenericChannel alloc] initWithNamespace:namespace];
+    newChannel.delegate = self;
+    self.genericChannels[namespace] = newChannel;
+    [currentSession addChannel:newChannel];
+
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[NSString stringWithFormat:@"Namespace %@ not found",namespace]];
     
-    if (channel != nil) {
+    if(newChannel != nil) {
         GCKError* error = nil;
-        [channel sendTextMessage:message error:&error];
+        [newChannel sendTextMessage:message error:&error];
         if (error != nil) {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.description];
         } else {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         }
     }
-    
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)mediaSeekWithCommand:(CDVInvokedUrlCommand*)command position:(NSTimeInterval)position resumeState:(GCKMediaResumeState)resumeState {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR.

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes issue https://github.com/jellyfin/cordova-plugin-chromecast/issues/78


### Description
Creates a new channel when sendMessage method is required.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested on iPhone implementation of app using this plugin.


### Checklist
<!-- Place and x inside the [ ] to indicate completion -->

- [x] I've updated the documentation as necessary
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've run `npm test` and no errors were found (run `npm style` to auto-fix errors it can)
- [x] I've run the tests (See Readme)
- [x] I added automated test coverage as appropriate for this change (See Readme Contributing section)